### PR TITLE
Map example to manifest sample

### DIFF
--- a/example/example-input.json
+++ b/example/example-input.json
@@ -1,5 +1,4 @@
 {
-  "unique_identifier": "identifier_name",
   "label": "Label",
   "description": "Description",
   "unique-identifier": "2018_example_001",
@@ -29,7 +28,6 @@
     "viewingDirection": "left-to-right",
     "viewingHint": "paged",
     "pages": [{
-<<<<<<< HEAD
         "label": "009",
         "file": "009_output.tif",
         "iiif-server": "https://image-server.library.nd.edu:8182/iif/2"
@@ -48,21 +46,6 @@
         "label": "2018 049 004",
         "file": "2018_049_009.jpg",
         "iiif-server": "https://image-server.library.nd.edu:8182/iif/2"
-=======
-        "label": "File 1",
-        "file": "file1.jpg",
-        "iiif-server": "https://server.com/serverpath_to_file1.tiff"
-      },
-      {
-        "label": "File 2",
-        "file": "file2.jpg",
-        "iiif-server": "https://server.com/serverpath_to_file2.tiff"
-      },
-      {
-        "label": "File 3",
-        "file": "file3.jpg",
-        "iiif-server": "https://server.com/serverpath_to_file3.tiff"
->>>>>>> Update example-input.json
       }
     ]
   }],

--- a/example/example-input.json
+++ b/example/example-input.json
@@ -1,4 +1,5 @@
 {
+  "unique_identifier": "identifier_name",
   "label": "Label",
   "description": "Description",
   "unique-identifier": "2018_example_001",
@@ -25,8 +26,10 @@
   ],
   "sequences": [{
     "label": "sequency",
+    "viewingDirection": "left-to-right",
     "viewingHint": "paged",
     "pages": [{
+<<<<<<< HEAD
         "label": "009",
         "file": "009_output.tif",
         "iiif-server": "https://image-server.library.nd.edu:8182/iif/2"
@@ -45,6 +48,21 @@
         "label": "2018 049 004",
         "file": "2018_049_009.jpg",
         "iiif-server": "https://image-server.library.nd.edu:8182/iif/2"
+=======
+        "label": "File 1",
+        "file": "file1.jpg",
+        "iiif-server": "https://server.com/serverpath_to_file1.tiff"
+      },
+      {
+        "label": "File 2",
+        "file": "file2.jpg",
+        "iiif-server": "https://server.com/serverpath_to_file2.tiff"
+      },
+      {
+        "label": "File 3",
+        "file": "file3.jpg",
+        "iiif-server": "https://server.com/serverpath_to_file3.tiff"
+>>>>>>> Update example-input.json
       }
     ]
   }],

--- a/example/manifest.json
+++ b/example/manifest.json
@@ -1,0 +1,101 @@
+{
+  "@context": "http://iiif.io/api/presentation/2/context.json",
+  "@type": "sc:Manifest",
+  "@id": "https://server.com/iiif/identifer_name/manifest",
+
+  "label": "Label",
+  "metadata": [{
+      "label": "Title",
+      "value": "Wunder der Vererbung"
+    },
+    {
+      "label": "Author(s)",
+      "value": "Bolle, Fritz"
+    },
+    {
+      "label": "Publication date",
+      "value": "[1951]"
+    },
+    {
+      "label": "Attribution",
+      "value": "Wellcome Library<br/>License: CC-BY-NC"
+    }
+  ],
+  "description": "Description",
+
+  "license": "rights",
+  "attribution": "attribution",
+
+  "sequences": [
+    {
+      "@id": "https://server.com/iiif/identifer_name/sequence/normal",
+      "@type": "sc:Sequence",
+      "label": "sequency",
+
+      "viewingDirection": "left-to-right",
+      "viewingHint": "paged",
+
+      "canvases": [
+        {
+          "@id": "https://server.com/iiif/identifer_name/canvas/p1",
+          "@type": "sc:Canvas",
+          "label": "File 1",
+          "height": 100,
+          "width": 100,
+          "images": [{
+              "@id": "https://server.com/iiif/identifer_name/image/file1.jpg",
+              "@type": "oa:Annotation",
+              "resources": [{
+                "@id": "https://server.com/serverpath_to_file1.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": [{
+                  "@id": "https://server.com/serverpath_to_file1.tiff",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }]
+              }]
+          }],
+        },
+        {
+          "@id": "https://server.com/iiif/identifer_name/canvas/p2",
+          "@type": "sc:Canvas",
+          "label": "File 2",
+          "height": 100,
+          "width": 100,
+          "images": [{
+              "@id": "https://server.com/iiif/identifer_name/image/file2.jpg",
+              "@type": "oa:Annotation",
+              "resources": [{
+                "@id": "https://server.com/serverpath_to_file2.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": [{
+                  "@id": "https://server.com/serverpath_to_file2.tiff",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }]
+              }]
+          }],
+        },
+        {
+          "@id": "https://server.com/iiif/identifer_name/canvas/p3",
+          "@type": "sc:Canvas",
+          "label": "File 3",
+          "height": 100,
+          "width": 100,
+          "images": [{
+              "@id": "https://server.com/iiif/identifer_name/image/file3.jpg",
+              "@type": "oa:Annotation",
+              "resources": [{
+                "@id": "https://server.com/serverpath_to_file3.tiff/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+                "service": [{
+                  "@id": "https://server.com/serverpath_to_file3.tiff",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }]
+              }]
+          }],
+        }
+      ]
+  }]
+}

--- a/example/manifest.json
+++ b/example/manifest.json
@@ -1,7 +1,7 @@
 {
   "@context": "http://iiif.io/api/presentation/2/context.json",
   "@type": "sc:Manifest",
-  "@id": "https://server.com/iiif/identifer_name/manifest",
+  "@id": "https://manifest.nd.edu/iiif/2018_example_001/manifest",
 
   "label": "Label",
   "metadata": [{
@@ -28,69 +28,109 @@
 
   "sequences": [
     {
-      "@id": "https://server.com/iiif/identifer_name/sequence/normal",
+      "@id": "https://manifest.nd.edu/iiif/2018_example_001/sequence/normal",
       "@type": "sc:Sequence",
       "label": "sequency",
-
       "viewingDirection": "left-to-right",
       "viewingHint": "paged",
 
       "canvases": [
         {
-          "@id": "https://server.com/iiif/identifer_name/canvas/p1",
+          "@id": "https://manifest.nd.edu/iiif/2018_example_001/canvas/p1",
           "@type": "sc:Canvas",
-          "label": "File 1",
-          "height": 100,
-          "width": 100,
+
+          "label": "009",
+          "height": 1000,
+          "width": 1000,
+
           "images": [{
-              "@id": "https://server.com/iiif/identifer_name/image/file1.jpg",
+              "@id": "https://manifest.nd.edu/iif/2018_example_001/images/009_output.tif",
               "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://manifest.nd.edu/iiif/2018_example_001/canvas/p1",
+
               "resources": [{
-                "@id": "https://server.com/serverpath_to_file1.tiff/full/full/0/default.jpg",
+                "@id": "https://image-server.library.nd.edu:8182/iif/2/009_output.tif/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
+
                 "service": [{
-                  "@id": "https://server.com/serverpath_to_file1.tiff",
+                  "@id": "https://manifest.nd.edu/iif/2018_example_001/images/",
                   "profile": "http://iiif.io/api/image/2/level2.json"
                 }]
               }]
           }],
         },
         {
-          "@id": "https://server.com/iiif/identifer_name/canvas/p2",
+          "@id": "https://manifest.nd.edu/iiif/2018_example_001/canvas/p2",
           "@type": "sc:Canvas",
-          "label": "File 2",
-          "height": 100,
-          "width": 100,
+          "label": "046",
+          "height": 1000,
+          "width": 1000,
+
           "images": [{
-              "@id": "https://server.com/iiif/identifer_name/image/file2.jpg",
+              "@id": "https://manifest.nd.edu/iif/2018_example_001/images/046_output.tif",
               "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://manifest.nd.edu/iiif/2018_example_001/canvas/p2",
+
               "resources": [{
-                "@id": "https://server.com/serverpath_to_file2.tiff/full/full/0/default.jpg",
+                "@id": "https://image-server.library.nd.edu:8182/iif/2/046_output.tif/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
+
                 "service": [{
-                  "@id": "https://server.com/serverpath_to_file2.tiff",
+                  "@id": "https://manifest.nd.edu/iif/2018_example_001/images/",
                   "profile": "http://iiif.io/api/image/2/level2.json"
                 }]
               }]
           }],
         },
         {
-          "@id": "https://server.com/iiif/identifer_name/canvas/p3",
+          "@id": "https://manifest.nd.edu/iiif/2018_example_001/canvas/p3",
           "@type": "sc:Canvas",
-          "label": "File 3",
-          "height": 100,
-          "width": 100,
+          "label": "2018 009",
+          "height": 1000,
+          "width": 1000,
+
           "images": [{
-              "@id": "https://server.com/iiif/identifer_name/image/file3.jpg",
+              "@id": "https://manifest.nd.edu/iif/2018_example_001/images/2018_009.jpg",
               "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://manifest.nd.edu/iiif/2018_example_001/canvas/p3",
+
               "resources": [{
-                "@id": "https://server.com/serverpath_to_file3.tiff/full/full/0/default.jpg",
+                "@id": "https://image-server.library.nd.edu:8182/iif/2/2018_009.jpg/full/full/0/default.jpg",
                 "@type": "dctypes:Image",
                 "format": "image/jpeg",
+
                 "service": [{
-                  "@id": "https://server.com/serverpath_to_file3.tiff",
+                  "@id": "https://manifest.nd.edu/iif/2018_example_001/images/",
+                  "profile": "http://iiif.io/api/image/2/level2.json"
+                }]
+              }]
+          }],
+        }
+        {
+          "@id": "https://manifest.nd.edu/iiif/2018_example_001/canvas/p4",
+          "@type": "sc:Canvas",
+          "label": "2018 049 004",
+          "height": 1000,
+          "width": 1000,
+
+          "images": [{
+              "@id": "https://manifest.nd.edu/iif/2018_example_001/images/2018_049_009.jpg",
+              "@type": "oa:Annotation",
+              "motivation": "sc:painting",
+              "on": "https://manifest.nd.edu/iiif/2018_example_001/canvas/p4",
+
+              "resources": [{
+                "@id": "https://image-server.library.nd.edu:8182/iif/2/2018_049_009.jpg/full/full/0/default.jpg",
+                "@type": "dctypes:Image",
+                "format": "image/jpeg",
+
+                "service": [{
+                  "@id": "https://manifest.nd.edu/iif/2018_example_001/images/",
                   "profile": "http://iiif.io/api/image/2/level2.json"
                 }]
               }]


### PR DESCRIPTION
Create sample manifest based on data in example-input.json.

Remove duplicate unique-identifier key from example.

Question: Is service key needed for images key? In [one of our actual manifests](https://s3-us-west-2.amazonaws.com/mellon-data-broker-dev-publicbucket-856nkug1cnvl/manifest_prod.json), service is only used for the thumbnail. 