### PR TITLE
Generic manifest creation process

### DIFF
--- a/manifest-from-input-json/create_manifest.py
+++ b/manifest-from-input-json/create_manifest.py
@@ -1,131 +1,42 @@
-import json
+# Creates json manifest based on appropriately structured input json.
+# to run, navigate to directory /manifest-from-input-json and execute command
+#  python3 create_manifest.py ../example/ example-input.json ./
 
-result_json = {}
-config = {}
-global_data = {}
+# parameters:
+#   - input directory (../example/)
+#   - file to process (example-input.json)
+#   - output directory (optional) - if not included, file is created in input
 
-#Start Function definitions
-def get_config_param():
-    global config
-    config['input-base-url'] = '/Users/lrobins5/git/mellon-manifest-pipeline/example/'
-    config['input-file-name'] = 'example-input.json'
-    config['input-file'] = config['input-base-url'] + config['input-file-name']
+from processJson import processJson
+import sys
 
-    config['output-base-url'] = '/Users/lrobins5/git/mellon-manifest-pipeline/example/'
-    config['output-file-suffix'] = '-manifest.json'
-
-def load_global_data( input_json ):
-    global global_data
-    global_data['id-base'] = input_json['manifest-base-url'] + 'iiif' + input_json['unique-identifier'] + '/'
-    global_data['output-file'] = config['output-base-url'] + input_json['unique-identifier'] + config['output-file-suffix']
-    global_data['iiif-server'] = input_json['iiif-server']
-    global_data['@context'] = 'http://iiif.io/api/presentation/2/context.json'
-    global_data['default-height'] = 1000
-    global_data['default-width'] = 1000
-    global_data['viewingDirection'] = 'left-to-right'
-
-# build results_json
-def create_manifest_json( input_json ):
-    global config
-    global result_json
-    global global_data
-    load_global_data( input_json )
-
-    result_json['@context'] = global_data['@context']
-    result_json['@type'] = 'sc:Manifest'
-    result_json['@id'] = global_data['id-base'] + 'manifest'
-    result_json['label'] = input_json['label']
-    result_json['metadata'] = input_json['metadata']
-    result_json['description'] = input_json['description']
-    result_json['license'] = input_json['rights']
-    result_json['attribution'] = input_json['attribution']
-    # currently, one sequence is allowed per manifest
-    sequence_data = input_json['sequences'][0]
-    add_sequence( sequence_data)
-
-def add_sequence( sequence_data ):
-    global result_json
-    global global_data
-    result_json['sequences'] = []
-
-    this_item = {}
-    this_item['@id'] = global_data['id-base'] + 'sequence/normal'
-    this_item['@type'] = 'sc:Sequence'
-    this_item['label'] = sequence_data['label']
-    this_item['viewingDirection'] = global_data['viewingDirection']
-    this_item['viewingHint'] = sequence_data['viewingHint']
-
-    result_json['sequences'] = []
-    result_json['sequences'].append(this_item)
-
-    # each input page gets a new canvas and image
-    if 'pages' in sequence_data:
-        result_json['sequences'][0]['canvases'] = []
-        i = 0
-        for page_data in sequence_data['pages']:
-            add_new_canvas_data(page_data, i)
-            i = i + 1
-
-def add_new_canvas_data( page_data, i ):
-    global result_json
-    global global_data
-    this_item = {}
-    this_item['@id'] = global_data['id-base'] + 'canvas/p' + str(i + 1)
-    this_item['@type'] = 'sc:Canvas'
-    this_item['label'] = page_data['label']
-    this_item['height'] = global_data['default-height']
-    this_item['width'] = global_data['default-width']
-    result_json['sequences'][0]['canvases'].append(this_item)
-    add_image_to_canvas(page_data, i)
-
-def add_image_to_canvas( page_data, i ):
-    global result_json
-    global global_data
-    result_json['sequences'][0]['canvases'][i]['images'] = []
-    this_item = {}
-    this_item['@id'] = global_data['id-base'] + 'images/' + page_data['file']
-    this_item['@type'] = 'oa:Annotation'
-    this_item['motivation'] = 'sc:painting'
-    this_item['on'] = result_json['sequences'][0]['canvases'][i]['@id']
-    result_json['sequences'][0]['canvases'][i]['images'].append(this_item)
-    add_resource_to_image(page_data, i)
-
-def add_resource_to_image( page_data, i ):
-    global result_json
-    global global_data
-    result_json['sequences'][0]['canvases'][i]['images'][0]['resources'] = []
-    this_item = {}
-    this_item['@id'] = global_data['iiif-server'] + '/' + page_data['file'] + '/full/full/0/default.jpg'
-    this_item['@type'] = 'dctypes:Image'
-    this_item['format'] = 'image/jpeg'
-    result_json['sequences'][0]['canvases'][i]['images'][0]['resources'].append(this_item)
-    add_service_to_resource( i )
-
-def add_service_to_resource(i):
-    global result_json
-    global global_data
-    result_json['sequences'][0]['canvases'][i]['images'][0]['resources'][0]['service'] = []
-    this_item = {}
-    this_item['@id'] = global_data['id-base'] + 'images/'
-    this_item['profile'] = "http://iiif.io/api/image/2/level2.json"
-    result_json['sequences'][0]['canvases'][i]['images'][0]['resources'][0]['service'].append(this_item)
+def handleError(errorMessage):
+    sys.exit(errorMessage)
 
 #start of main execution
 
-get_config_param()
+# instantiate a processing object
+processSet = processJson()
 
-# read input json file
-input_source = open(config['input-file'], 'r')
-input_json = json.loads(input_source.read())
-input_source.close()
+# parameters required
+if len(sys.argv) < 3:
+    handleError(processSet.errorInputRequired())
 
-create_manifest_json( input_json )
+# handle input parameters...
+inputDirectory = sys.argv[1]
+inputFile = sys.argv[2]
+# file created in input directory if not specified
+outputDirectory = inputDirectory
+if len(sys.argv) > 3:
+    outputDirectory = sys.argv[3]
 
-#print resulting json to STDOUT
-print(json.dumps(result_json, indent=2))
+# verify that the input file exists - exit on error
+if processSet.verifyInput(inputDirectory, inputFile, outputDirectory) == False:
+    handleError(processSet.error)
 
-# write data to manifest file
+# generate json manifest
+processSet.buildManifest()
 
-with open(global_data['output-file'], 'w') as output_file:
-    json.dump(result_json, output_file, indent=2)
-output_file.close()
+# output manifest
+processSet.printManifest() # print to STDOUT
+processSet.dumpManifest() # create file in output directory

--- a/manifest-from-input-json/processJson.py
+++ b/manifest-from-input-json/processJson.py
@@ -1,0 +1,127 @@
+import json, glob
+
+class processJson():
+    def __init__(self):
+        self.result_json = {}
+        self.config = {}
+        self.global_data = {}
+        self.error = ''
+
+    def _set_file_data(self, inputDirectory, inputFile, outputDirectory):
+        self.input_file = inputDirectory + inputFile
+
+        self.output_base_url = outputDirectory
+        self.output_file_suffix = '-manifest.json'
+
+    def _load_global_data( self, input_json ):
+        self.global_data['id-base'] = input_json['manifest-base-url'] + 'iiif' + input_json['unique-identifier'] + '/'
+        self.global_data['output-file'] = self.output_base_url + input_json['unique-identifier'] + self.output_file_suffix
+        self.global_data['iiif-server'] = input_json['iiif-server']
+        self.global_data['@context'] = 'http://iiif.io/api/presentation/2/context.json'
+        self.global_data['default-height'] = 1000
+        self.global_data['default-width'] = 1000
+        self.global_data['viewingDirection'] = 'left-to-right'
+
+    # build results_json
+    def _create_manifest_json( self, input_json ):
+        self._load_global_data( input_json )
+
+        self.result_json['@context'] = self.global_data['@context']
+        self.result_json['@type'] = 'sc:Manifest'
+        self.result_json['@id'] = self.global_data['id-base'] + 'manifest'
+        self.result_json['label'] = input_json['label']
+        self.result_json['metadata'] = input_json['metadata']
+        self.result_json['description'] = input_json['description']
+        self.result_json['license'] = input_json['rights']
+        self.result_json['attribution'] = input_json['attribution']
+        # currently, one sequence is allowed per manifest
+        sequence_data = input_json['sequences'][0]
+        self._add_sequence( sequence_data)
+
+    def _add_sequence( self, sequence_data ):
+        self.result_json['sequences'] = []
+
+        this_item = {}
+        this_item['@id'] = self.global_data['id-base'] + 'sequence/normal'
+        this_item['@type'] = 'sc:Sequence'
+        this_item['label'] = sequence_data['label']
+        this_item['viewingDirection'] = self.global_data['viewingDirection']
+        this_item['viewingHint'] = sequence_data['viewingHint']
+
+        self.result_json['sequences'] = []
+        self.result_json['sequences'].append(this_item)
+
+        # each input page gets a new canvas and image
+        if 'pages' in sequence_data:
+            self.result_json['sequences'][0]['canvases'] = []
+            i = 0
+            for page_data in sequence_data['pages']:
+                self._add_new_canvas_data(page_data, i)
+                i = i + 1
+
+    def _add_new_canvas_data( self, page_data, i ):
+        this_item = {}
+        this_item['@id'] = self.global_data['id-base'] + 'canvas/p' + str(i + 1)
+        this_item['@type'] = 'sc:Canvas'
+        this_item['label'] = page_data['label']
+        this_item['height'] = self.global_data['default-height']
+        this_item['width'] = self.global_data['default-width']
+        self.result_json['sequences'][0]['canvases'].append(this_item)
+        self._add_image_to_canvas(page_data, i)
+
+    def _add_image_to_canvas( self, page_data, i ):
+        self.result_json['sequences'][0]['canvases'][i]['images'] = []
+        this_item = {}
+        this_item['@id'] = self.global_data['id-base'] + 'images/' + page_data['file']
+        this_item['@type'] = 'oa:Annotation'
+        this_item['motivation'] = 'sc:painting'
+        this_item['on'] = self.result_json['sequences'][0]['canvases'][i]['@id']
+        self.result_json['sequences'][0]['canvases'][i]['images'].append(this_item)
+        self._add_resource_to_image(page_data, i)
+
+    def _add_resource_to_image( self, page_data, i ):
+        self.result_json['sequences'][0]['canvases'][i]['images'][0]['resources'] = []
+        this_item = {}
+        this_item['@id'] = self.global_data['iiif-server'] + '/' + page_data['file'] + '/full/full/0/default.jpg'
+        this_item['@type'] = 'dctypes:Image'
+        this_item['format'] = 'image/jpeg'
+        self.result_json['sequences'][0]['canvases'][i]['images'][0]['resources'].append(this_item)
+        self._add_service_to_resource( i )
+
+    def _add_service_to_resource(self, i):
+        self.result_json['sequences'][0]['canvases'][i]['images'][0]['resources'][0]['service'] = []
+        this_item = {}
+        this_item['@id'] = self.global_data['id-base'] + 'images/'
+        this_item['profile'] = "http://iiif.io/api/image/2/level2.json"
+        self.result_json['sequences'][0]['canvases'][i]['images'][0]['resources'][0]['service'].append(this_item)
+
+    # returns True if input file found, false otherwise
+    def verifyInput(self, inputDirectory, inputFile, outputDirectory):
+        self._set_file_data(inputDirectory, inputFile, outputDirectory)
+        main_match = glob.glob(self.input_file)
+        if not main_match:
+            self.error = 'Error: ' + self.input_file + ' not found'
+            return False
+        return True
+
+    # returns error string
+    def errorInputRequired(self):
+        self.error = 'Input directory and file name are required.'
+        return self.error
+
+    # start of main execution
+    def buildManifest(self):
+        with open(self.input_file, 'r') as input_source:
+            input_json = json.loads(input_source.read())
+        input_source.close()
+        self._create_manifest_json(input_json)
+
+    #print resulting json to STDOUT
+    def printManifest(self):
+        print(json.dumps(self.result_json, indent=2))
+
+    # write data to manifest json file
+    def dumpManifest(self):
+        with open(self.global_data['output-file'], 'w') as output_file:
+            json.dump(self.result_json, output_file, indent=2)
+        output_file.close()


### PR DESCRIPTION
Break manifest creation into a class.
Allow input of directories and file name for generic processing.

(still needs tests written)