### PR TITLE
Added a script to do a local deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,3 +201,13 @@ Now to run the script:
 EX:
 
 ```python3 manifest_util.py --rerun --bucket mybucket -s arn:aws:states:us-east-1:1234567890:stateMachine:StateMachine-IH8SMHeRe -e events.txt```
+
+
+# Local Deploy
+
+Run the script local-deploy providing the name of the stack you want to deploy and the
+path to the mellon-blueprints repo
+
+```bash
+./local-deploy.sh manifest-pipeline-jon ../mellon-blueprints/
+```

--- a/local-deploy.sh
+++ b/local-deploy.sh
@@ -1,0 +1,37 @@
+PROGNAME=$0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+usage() {
+  cat << EOF >&2
+Usage: $PROGNAME stackname path-to-blueprints
+
+Deployes the pipeline to the stage
+Note: Ensure you have an env variable S3_BUCKET as the bucket to deploy to.
+
+EOF
+  exit 1
+}
+``
+stackname=$1
+blueprints_path=$2
+
+if [ -z ${S3_BUCKET+x} ]; then
+  usage
+  exit 1
+fi
+
+export CODEBUILD_SRC_DIR=`pwd`
+export CODEBUILD_SRC_DIR_ConfigCode=`pwd`/$blueprints_path
+
+./scripts/codebuild/install.sh
+./scripts/codebuild/pre_build.sh
+./scripts/codebuild/build.sh
+./scripts/codebuild/post_build.sh
+
+aws cloudformation deploy --template-file output.yml --stack-name $stackname \
+  --capabilities CAPABILITY_IAM
+
+rm -rf $CODEBUILD_SRC_DIR/output.yml

--- a/scripts/codebuild/pre_build.sh
+++ b/scripts/codebuild/pre_build.sh
@@ -1,4 +1,5 @@
 echo "[Pre-Build phase] `date` in `pwd`"
 
-echo "Copy the resource.yml to this project so it can run"
+echo "Copy the manifest-pipeline.yml to this project so it can run"
+echo "$CODEBUILD_SRC_DIR_ConfigCode/deploy/cloudformation/manifest-pipeline.yml"
 cp $CODEBUILD_SRC_DIR_ConfigCode/deploy/cloudformation/manifest-pipeline.yml $CODEBUILD_SRC_DIR/


### PR DESCRIPTION
There is now a script to do deployment! 
This will mimic what happens with the codepipeline and even share many of the same commands!

Example:  ./local-deploy.sh stack-name path-to-mellon-blueprints-on-your-machine 

There are 2 params
1. stack-name - the name of your stack as a note compared to how we have done stach names in the past this is the full name you want to use as a stack name. 
2. path-to-mellon-blueprints-on-your-machine - you have to have the mellon-blueprints down to do this build.  


