### PR TITLE
Changes to address deploy and more ssm organization

### DIFF
--- a/json-from-csv/handler.py
+++ b/json-from-csv/handler.py
@@ -34,7 +34,7 @@ def get_config():
     # read the keys we want out of ssm
     client = boto3.client('ssm')
     paginator = client.get_paginator('get_parameters_by_path')
-    path = '/all/stacks/' + os.environ['SSM_KEY_BASE'] + '/config/'
+    path = os.environ['SSM_KEY_BASE'] + '/'
     page_iterator = paginator.paginate(
         Path = path,
         Recursive=True,
@@ -51,7 +51,7 @@ def get_config():
         # add the key/value pair
         config[key] = value
 
-    config['image-server-base-url'] = "https://" + config['image-server-base-url'] + '/iiif/2/'
+    config['image-server-base-url'] = "https://" + config['image-server-base-url'] + ':8182/iiif/2'
 
     return config
 

--- a/local-deploy.sh
+++ b/local-deploy.sh
@@ -29,6 +29,7 @@ fi
 ./scripts/codebuild/post_build.sh
 
 aws cloudformation deploy --template-file output.yml --stack-name $stackname \
-  --capabilities CAPABILITY_NAMED_IAM
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides AppConfigPath="/all/$stackname"
 
 rm -rf output.yml

--- a/manifest_util.py
+++ b/manifest_util.py
@@ -91,6 +91,8 @@ def _get_events(file):
     except IOError:
         _add_validation_error('Cannot open ' + file)
         return []
+
+    lines = list(filter(None, lines))
     return lines
 
 def _setup_event(args):
@@ -107,7 +109,7 @@ def _setup_event(args):
         except Exception as e:
             _add_process_error(e,event)
             return
-            
+
 
 def _get_last_run_objects(event, args):
     cfg = _get_config(args)


### PR DESCRIPTION
These changes started because I was having trouble deploying likely because I had changed the logical name of an ssm key but not the path associated with it.

But the main reason that they were done is that we wish to separate ssm key associated with application configuration and those that are used for stack infrastructure in the ssm path key. So I moved my config oriented params to the config path location.